### PR TITLE
Fix: Use system default dark appearance

### DIFF
--- a/Sources/SettingTheme.swift
+++ b/Sources/SettingTheme.swift
@@ -30,7 +30,7 @@ public enum SettingTheme {
 
     public static var backgroundColor: Color = {
         #if os(iOS)
-            return Color(uiColor: .systemBackground)
+            return Color(uiColor: .secondarySystemGroupedBackground)
         #else
             return Color(nsColor: .textBackgroundColor)
         #endif
@@ -38,7 +38,7 @@ public enum SettingTheme {
 
     public static var secondaryBackgroundColor: Color = {
         #if os(iOS)
-            return Color(uiColor: .secondarySystemBackground)
+            return Color(uiColor: .systemGroupedBackground)
         #else
             return Color(nsColor: .windowBackgroundColor)
         #endif


### PR DESCRIPTION
Changes the background and secondary background colors in `SettingTheme` to match the system’s default dark appearance (darker background and lighter list item background)

The change does not affect the light appearance.

Setting currently looks like this in dark appearance:

<img src="https://user-images.githubusercontent.com/9888537/229631194-ce34d1b7-706d-4014-963d-394f3b4c0776.png" alt="Old Appearance" width="300px">

This merge request uses the colors `.secondarySystemGroupedBackground` and `.systemGroupedBackground` instead which looks like this:

<img src="https://user-images.githubusercontent.com/9888537/229631654-7777105c-71a0-4768-be75-313acae65cd4.png" alt="New Appearance" width="300px">

For comparison, the Settings app looks like this:

<img src="https://user-images.githubusercontent.com/9888537/229631731-e1d117ff-8005-4ac5-a8df-404ab01bca0f.png" alt="Settings" width="300px">