### PR TITLE
Icon support for SettingButton and SettingPicker and trailing label support for SettingPage

### DIFF
--- a/Sources/Views/SettingButton.swift
+++ b/Sources/Views/SettingButton.swift
@@ -13,6 +13,7 @@ import SwiftUI
  */
 public struct SettingButton: View, Setting {
     public var id: AnyHashable?
+    public var icon: SettingIcon?
     public var title: String
     public var indicator: String? = "arrow.up.forward"
     public var horizontalSpacing = CGFloat(12)
@@ -22,6 +23,7 @@ public struct SettingButton: View, Setting {
 
     public init(
         id: AnyHashable? = nil,
+        icon: SettingIcon? = nil,
         title: String,
         indicator: String? = "arrow.up.forward",
         horizontalSpacing: CGFloat = CGFloat(12),
@@ -30,6 +32,7 @@ public struct SettingButton: View, Setting {
         action: @escaping () -> Void
     ) {
         self.id = id
+        self.icon = icon
         self.title = title
         self.indicator = indicator
         self.horizontalSpacing = horizontalSpacing
@@ -40,6 +43,7 @@ public struct SettingButton: View, Setting {
 
     public var body: some View {
         SettingButtonView(
+            icon: icon,
             title: title,
             indicator: indicator,
             horizontalSpacing: horizontalSpacing,
@@ -51,6 +55,7 @@ public struct SettingButton: View, Setting {
 }
 
 struct SettingButtonView: View {
+    var icon: SettingIcon?
     let title: String
     var indicator: String? = "arrow.up.forward"
     var horizontalSpacing = CGFloat(12)
@@ -61,6 +66,10 @@ struct SettingButtonView: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: horizontalSpacing) {
+                if let icon {
+                    SettingIconView(icon: icon)
+                }
+
                 Text(title)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Views/SettingPage.swift
+++ b/Sources/Views/SettingPage.swift
@@ -14,6 +14,7 @@ import SwiftUI
 public struct SettingPage: Setting {
     public var id: AnyHashable?
     public var title: String
+    public var selectedChoice: String?
     public var spacing = CGFloat(20)
     public var verticalPadding = CGFloat(6)
     public var backgroundColor = SettingTheme.secondaryBackgroundColor
@@ -24,6 +25,7 @@ public struct SettingPage: Setting {
     public init(
         id: AnyHashable? = nil,
         title: String,
+        selectedChoice: String? = nil,
         spacing: CGFloat = CGFloat(20),
         verticalPadding: CGFloat = CGFloat(6),
         backgroundColor: Color = SettingTheme.secondaryBackgroundColor,
@@ -33,6 +35,7 @@ public struct SettingPage: Setting {
     ) {
         self.id = id
         self.title = title
+        self.selectedChoice = selectedChoice
         self.spacing = spacing
         self.verticalPadding = verticalPadding
         self.backgroundColor = backgroundColor
@@ -159,6 +162,7 @@ struct SettingPageView<Content>: View where Content: View {
 
 struct SettingPagePreviewView: View {
     let title: String
+    var selectedChoice: String?
     var icon: SettingIcon?
     var indicator = "chevron.forward"
     var horizontalSpacing = CGFloat(12)
@@ -175,6 +179,11 @@ struct SettingPagePreviewView: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, verticalPadding)
+
+            if let selectedChoice {
+                Text(selectedChoice)
+                    .foregroundColor(SettingTheme.secondaryLabelColor)
+            }
 
             Image(systemName: indicator)
                 .foregroundColor(SettingTheme.secondaryLabelColor)

--- a/Sources/Views/SettingPicker.swift
+++ b/Sources/Views/SettingPicker.swift
@@ -13,6 +13,7 @@ import SwiftUI
  */
 public struct SettingPicker: View, Setting {
     public var id: AnyHashable?
+    public var icon: SettingIcon?
     public var title: String
     public var choices: [String]
     @Binding public var selectedIndex: Int
@@ -23,6 +24,7 @@ public struct SettingPicker: View, Setting {
 
     public init(
         id: AnyHashable? = nil,
+        icon: SettingIcon? = nil,
         title: String,
         choices: [String],
         selectedIndex: Binding<Int>,
@@ -32,6 +34,7 @@ public struct SettingPicker: View, Setting {
         choicesConfiguration: ChoicesConfiguration = ChoicesConfiguration()
     ) {
         self.id = id
+        self.icon = icon
         self.title = title
         self.choices = choices
         self._selectedIndex = selectedIndex
@@ -92,6 +95,7 @@ public struct SettingPicker: View, Setting {
 
     public var body: some View {
         SettingPickerView(
+            icon: icon,
             title: title,
             choices: choices,
             selectedIndex: $selectedIndex,
@@ -113,6 +117,7 @@ public extension SettingPicker {
 }
 
 struct SettingPickerView: View {
+    var icon: SettingIcon?
     let title: String
     var choices: [String]
     @Binding var selectedIndex: Int
@@ -130,6 +135,10 @@ struct SettingPickerView: View {
                 isActive = true
             } label: {
                 HStack(spacing: horizontalSpacing) {
+                    if let icon {
+                        SettingIconView(icon: icon)
+                    }
+
                     Text(title)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Views/SettingView.swift
+++ b/Sources/Views/SettingView.swift
@@ -37,6 +37,7 @@ struct SettingView: View {
                 } label: {
                     SettingPagePreviewView(
                         title: page.title,
+                        selectedChoice: page.selectedChoice,
                         icon: page.previewConfiguration.icon,
                         indicator: page.previewConfiguration.indicator,
                         horizontalSpacing: page.previewConfiguration.horizontalSpacing,


### PR DESCRIPTION
Thanks for creating an awesome library! 

This PR implements icon support for SettingButton and SettingPicker, as well as trailing label support for SettingPage, to ensure consistency with the look and feel of iOS Settings.