### PR TITLE
fix: correct dark theme and make searchbar optional

### DIFF
--- a/Example/SettingExample/PreferencesView.swift
+++ b/Example/SettingExample/PreferencesView.swift
@@ -28,7 +28,7 @@ struct PreferencesView: View {
     @StateObject var model = PreferencesViewModel()
 
     var body: some View {
-        SettingStack {
+        SettingStack(isSearchable: false) { // if you want to show the searchbar just change the condition to true
             SettingPage(title: "Preferences") {
                 SettingGroup {
                     SettingPage(

--- a/Sources/SettingTheme.swift
+++ b/Sources/SettingTheme.swift
@@ -30,7 +30,7 @@ public enum SettingTheme {
 
     public static var backgroundColor: Color = {
         #if os(iOS)
-            return Color(uiColor: .systemBackground)
+            return Color(uiColor: .secondarySystemGroupedBackground)
         #else
             return Color(nsColor: .textBackgroundColor)
         #endif
@@ -38,7 +38,7 @@ public enum SettingTheme {
 
     public static var secondaryBackgroundColor: Color = {
         #if os(iOS)
-            return Color(uiColor: .secondarySystemBackground)
+            return Color(uiColor: .systemGroupedBackground)
         #else
             return Color(nsColor: .windowBackgroundColor)
         #endif


### PR DESCRIPTION
This commit fixes the dark theme by changing the background color to .secondarySystemGroupedBackground and the secondary background color to .systemGroupedBackground (as default in iOS). It also makes the search bar optional by adding a boolean parameter "isSearchable" to SettingStack.