### PR TITLE
hide TabBar when navigate to a new view

### DIFF
--- a/Sources/Views/SettingPicker.swift
+++ b/Sources/Views/SettingPicker.swift
@@ -233,7 +233,7 @@ struct SettingPickerChoicesView: View {
 
     var body: some View {
         SettingPageView(title: title, navigationTitleDisplayMode: choicesConfiguration.pageNavigationTitleDisplayMode) {
-            SettingGroupView(
+            let settingGroupView = SettingGroupView(
                 header: choicesConfiguration.groupHeader,
                 footer: choicesConfiguration.groupFooter,
                 horizontalPadding: choicesConfiguration.groupHorizontalPadding,
@@ -262,6 +262,14 @@ struct SettingPickerChoicesView: View {
                     .buttonStyle(.row)
                 }
             }
+            #if os(iOS)
+                if #available(iOS 16.0, *) {
+                    settingGroupView.toolbar(.hidden, for: .tabBar)
+                } else {
+                    settingGroupView
+                }
+            #endif
+                settingGroupView
         }
     }
 }

--- a/Sources/Views/SettingView.swift
+++ b/Sources/Views/SettingView.swift
@@ -48,13 +48,22 @@ struct SettingView: View {
                 .buttonStyle(.row)
                 .background {
                     NavigationLink(isActive: $isActive) {
-                        SettingView(setting: page, isPagePreview: false)
+                        #if os(iOS)
+                            if #available(iOS 16.0, *) {
+                                SettingView(setting: page, isPagePreview: false)
+                                    .toolbar(.hidden, for: .tabBar)
+                            } else {
+                                SettingView(setting: page, isPagePreview: false)
+                            }
+                        #else
+                            SettingView(setting: page, isPagePreview: false)
+                        #endif
                     } label: {
                         EmptyView()
                     }
                     .opacity(0)
                 }
-
+                
             } else {
                 SettingPageView(
                     title: page.title,


### PR DESCRIPTION
this change will hide `TabBar` when user navigate into `SettingPage` or `SettingPicker`

https://github.com/aheze/Setting/assets/52348220/550d104c-2554-405e-90f8-036144961778

