### PR TITLE
[PR] SettingToggle ~ Icon Support with fixes +new cfgs [#42]

### DIFF
--- a/Example/SettingExample/PreferencesView.swift
+++ b/Example/SettingExample/PreferencesView.swift
@@ -19,6 +19,7 @@ class PreferencesViewModel: ObservableObject {
     @AppStorage("notificationIndex") var notificationIndex = 0
     @AppStorage("notificationPromo") var notificationPromo = true
     @AppStorage("notificationUpdates") var notificationUpdates = true
+    @AppStorage("toggleIcon") var toggleUpdate = true
     @AppStorage("color") var color = 0xFF3100
     @AppStorage("text") var text = ""
     @Published var showingAlert = false
@@ -239,6 +240,17 @@ struct PreferencesView: View {
                             }
                             .icon(icon: .system(icon: "sparkles", backgroundColor: Color.pink))
                             .indicator("face.smiling")
+                        }
+
+                        SettingGroup {
+                            SettingToggle(
+                                icon: .system(icon: "globe", backgroundColor: Color.pink),
+                                title: "Toggle with Icon",
+                                isOn: $model.toggleUpdate,
+                                onChange: { _ in
+                                    print("Toggle is switched: \($model.toggleUpdate)")
+                                }
+                            )
                         }
                     }
                     .previewIcon(icon: .system(icon: "ellipsis", backgroundColor: Color.teal))

--- a/Sources/Views/SettingPicker.swift
+++ b/Sources/Views/SettingPicker.swift
@@ -22,7 +22,6 @@ public struct SettingPicker: View, Setting {
     public var verticalPadding = CGFloat(14)
     public var horizontalPadding: CGFloat?
     public var choicesConfiguration = ChoicesConfiguration()
-    public var iconArray: [SettingIcon]? // Add property for array of icons
 
     public init(
         id: AnyHashable? = nil,
@@ -34,11 +33,8 @@ public struct SettingPicker: View, Setting {
         horizontalSpacing: CGFloat = CGFloat(12),
         verticalPadding: CGFloat = CGFloat(14),
         horizontalPadding: CGFloat? = nil,
-        choicesConfiguration: ChoicesConfiguration = ChoicesConfiguration(),
-        iconArray: [SettingIcon]? = nil // Add parameter for array of icons
+        choicesConfiguration: ChoicesConfiguration = ChoicesConfiguration()
     ) {
-   
-  
         self.id = id
         self.icon = icon
         self.title = title
@@ -49,7 +45,6 @@ public struct SettingPicker: View, Setting {
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
         self.choicesConfiguration = choicesConfiguration
-        self.iconArray = iconArray // Assign array of icons
     }
 
     public enum PickerDisplayMode {
@@ -143,15 +138,13 @@ struct SettingPickerView: View {
 
     var body: some View {
         switch choicesConfiguration.pickerDisplayMode {
-         case .navigation:
+        case .navigation:
             Button {
                 isActive = true
             } label: {
                 HStack(spacing: horizontalSpacing) {
-                    if let iconArray = iconArray {
-                        ForEach(iconArray) { icon in // Loop through array of icons
-                            SettingIconView(icon: icon)
-                        }
+                    if let icon {
+                        SettingIconView(icon: icon)
                     }
 
                     Text(title)
@@ -186,7 +179,6 @@ struct SettingPickerView: View {
                 }
                 .opacity(0)
             }
-            
 
         case .menu:
             HStack(spacing: horizontalSpacing) {

--- a/Sources/Views/SettingPicker.swift
+++ b/Sources/Views/SettingPicker.swift
@@ -22,6 +22,7 @@ public struct SettingPicker: View, Setting {
     public var verticalPadding = CGFloat(14)
     public var horizontalPadding: CGFloat?
     public var choicesConfiguration = ChoicesConfiguration()
+    public var iconArray: [SettingIcon]? // Add property for array of icons
 
     public init(
         id: AnyHashable? = nil,
@@ -33,8 +34,11 @@ public struct SettingPicker: View, Setting {
         horizontalSpacing: CGFloat = CGFloat(12),
         verticalPadding: CGFloat = CGFloat(14),
         horizontalPadding: CGFloat? = nil,
-        choicesConfiguration: ChoicesConfiguration = ChoicesConfiguration()
+        choicesConfiguration: ChoicesConfiguration = ChoicesConfiguration(),
+        iconArray: [SettingIcon]? = nil // Add parameter for array of icons
     ) {
+   
+  
         self.id = id
         self.icon = icon
         self.title = title
@@ -45,6 +49,7 @@ public struct SettingPicker: View, Setting {
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
         self.choicesConfiguration = choicesConfiguration
+        self.iconArray = iconArray // Assign array of icons
     }
 
     public enum PickerDisplayMode {
@@ -138,13 +143,15 @@ struct SettingPickerView: View {
 
     var body: some View {
         switch choicesConfiguration.pickerDisplayMode {
-        case .navigation:
+         case .navigation:
             Button {
                 isActive = true
             } label: {
                 HStack(spacing: horizontalSpacing) {
-                    if let icon {
-                        SettingIconView(icon: icon)
+                    if let iconArray = iconArray {
+                        ForEach(iconArray) { icon in // Loop through array of icons
+                            SettingIconView(icon: icon)
+                        }
                     }
 
                     Text(title)
@@ -179,6 +186,7 @@ struct SettingPickerView: View {
                 }
                 .opacity(0)
             }
+            
 
         case .menu:
             HStack(spacing: horizontalSpacing) {

--- a/Sources/Views/SettingToggle.swift
+++ b/Sources/Views/SettingToggle.swift
@@ -12,6 +12,7 @@ public struct SettingToggle: View, Setting {
     public var id: AnyHashable?
     public var title: String
     @Binding public var isOn: Bool
+    public var icon: SettingIcon?
     public var horizontalSpacing = CGFloat(12)
     public var verticalPadding = CGFloat(14)
     public var horizontalPadding = CGFloat(16)
@@ -19,6 +20,7 @@ public struct SettingToggle: View, Setting {
 
     public init(
         id: AnyHashable? = nil,
+        icon: SettingIcon? = nil,
         title: String,
         isOn: Binding<Bool>,
         horizontalSpacing: CGFloat = CGFloat(12),
@@ -27,6 +29,7 @@ public struct SettingToggle: View, Setting {
         onChange: ((Bool) -> Void)? = nil // Initialize onChange closure
     ) {
         self.id = id
+        self.icon = icon
         self.title = title
         self._isOn = isOn
         self.horizontalSpacing = horizontalSpacing
@@ -37,6 +40,7 @@ public struct SettingToggle: View, Setting {
 
     public var body: some View {
         SettingToggleView(
+            icon: icon,
             title: title,
             isOn: $isOn,
             horizontalSpacing: horizontalSpacing,
@@ -48,6 +52,7 @@ public struct SettingToggle: View, Setting {
 }
 
 struct SettingToggleView: View {
+    let icon: SettingIcon?
     let title: String
     @Binding var isOn: Bool
 
@@ -58,6 +63,10 @@ struct SettingToggleView: View {
 
     var body: some View {
         HStack(spacing: horizontalSpacing) {
+            if let icon {
+              SettingIconView(icon: icon)
+            }
+            
             Text(title)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/Views/SettingToggle.swift
+++ b/Sources/Views/SettingToggle.swift
@@ -8,16 +8,14 @@
 
 import SwiftUI
 
-/**
- A simple toggle.
- */
 public struct SettingToggle: View, Setting {
     public var id: AnyHashable?
     public var title: String
     @Binding public var isOn: Bool
     public var horizontalSpacing = CGFloat(12)
     public var verticalPadding = CGFloat(14)
-    public var horizontalPadding: CGFloat? = nil
+    public var horizontalPadding = CGFloat(16)
+    public var onChange: ((Bool) -> Void)? // Add onChange closure
 
     public init(
         id: AnyHashable? = nil,
@@ -25,7 +23,8 @@ public struct SettingToggle: View, Setting {
         isOn: Binding<Bool>,
         horizontalSpacing: CGFloat = CGFloat(12),
         verticalPadding: CGFloat = CGFloat(14),
-        horizontalPadding: CGFloat? = nil
+        horizontalPadding: CGFloat = CGFloat(16),
+        onChange: ((Bool) -> Void)? = nil // Initialize onChange closure
     ) {
         self.id = id
         self.title = title
@@ -33,6 +32,7 @@ public struct SettingToggle: View, Setting {
         self.horizontalSpacing = horizontalSpacing
         self.verticalPadding = verticalPadding
         self.horizontalPadding = horizontalPadding
+        self.onChange = onChange // Assign onChange closure
     }
 
     public var body: some View {
@@ -41,20 +41,20 @@ public struct SettingToggle: View, Setting {
             isOn: $isOn,
             horizontalSpacing: horizontalSpacing,
             verticalPadding: verticalPadding,
-            horizontalPadding: horizontalPadding
+            horizontalPadding: horizontalPadding,
+            onChange: onChange // Pass onChange closure to SettingToggleView
         )
     }
 }
 
 struct SettingToggleView: View {
-    @Environment(\.edgePadding) var edgePadding
-    
     let title: String
     @Binding var isOn: Bool
 
     var horizontalSpacing = CGFloat(12)
     var verticalPadding = CGFloat(14)
-    var horizontalPadding: CGFloat? = nil
+    var horizontalPadding = CGFloat(16)
+    var onChange: ((Bool) -> Void)? // Receive onChange closure
 
     var body: some View {
         HStack(spacing: horizontalSpacing) {
@@ -65,8 +65,11 @@ struct SettingToggleView: View {
 
             Toggle("", isOn: $isOn)
                 .labelsHidden()
+                .onChange(of: isOn, perform: { newValue in
+                    onChange?(newValue) // Call onChange closure
+                })
         }
-        .padding(.horizontal, horizontalPadding ?? edgePadding)
+        .padding(.horizontal, horizontalPadding)
         .accessibilityElement(children: .combine)
     }
 }

--- a/Sources/Views/SettingToggle.swift
+++ b/Sources/Views/SettingToggle.swift
@@ -15,7 +15,7 @@ public struct SettingToggle: View, Setting {
     public var icon: SettingIcon?
     public var horizontalSpacing = CGFloat(12)
     public var verticalPadding = CGFloat(14)
-    public var horizontalPadding = CGFloat(16)
+    public var horizontalPadding: CGFloat? = nil
     public var onChange: ((Bool) -> Void)? // Add onChange closure
 
     public init(
@@ -25,7 +25,7 @@ public struct SettingToggle: View, Setting {
         isOn: Binding<Bool>,
         horizontalSpacing: CGFloat = CGFloat(12),
         verticalPadding: CGFloat = CGFloat(14),
-        horizontalPadding: CGFloat = CGFloat(16),
+        horizontalPadding: CGFloat? = nil,
         onChange: ((Bool) -> Void)? = nil // Initialize onChange closure
     ) {
         self.id = id
@@ -52,21 +52,23 @@ public struct SettingToggle: View, Setting {
 }
 
 struct SettingToggleView: View {
+    @Environment(\.edgePadding) var edgePadding
+
     let icon: SettingIcon?
     let title: String
     @Binding var isOn: Bool
 
     var horizontalSpacing = CGFloat(12)
     var verticalPadding = CGFloat(14)
-    var horizontalPadding = CGFloat(16)
+    var horizontalPadding: CGFloat? = nil
     var onChange: ((Bool) -> Void)? // Receive onChange closure
 
     var body: some View {
         HStack(spacing: horizontalSpacing) {
             if let icon {
-              SettingIconView(icon: icon)
+                SettingIconView(icon: icon)
             }
-            
+
             Text(title)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -78,7 +80,27 @@ struct SettingToggleView: View {
                     onChange?(newValue) // Call onChange closure
                 })
         }
-        .padding(.horizontal, horizontalPadding)
+        .padding(.horizontal, horizontalPadding ?? edgePadding)
         .accessibilityElement(children: .combine)
+    }
+}
+
+public extension SettingToggle {
+    func icon(_ icon: String, color: Color = .blue) -> SettingToggle {
+        var toggle = self
+        toggle.icon = .system(icon: icon, backgroundColor: color)
+        return toggle
+    }
+
+    func icon(_ icon: String, foregroundColor: Color = .white, backgroundColor: Color = .blue) -> SettingToggle {
+        var toggle = self
+        toggle.icon = .system(icon: icon, foregroundColor: foregroundColor, backgroundColor: backgroundColor)
+        return toggle
+    }
+
+    func icon(icon: SettingIcon) -> SettingToggle {
+        var toggle = self
+        toggle.icon = icon
+        return toggle
     }
 }


### PR DESCRIPTION
This PR implements #42 and fixes #37, #38.

Relevant commits:
- https://github.com/When-original-devs-wont-merge-good-PRs/Setting/commit/a9c04cf92506f0919e1365bee2d54fb47ddab9ac
- https://github.com/When-original-devs-wont-merge-good-PRs/Setting/commit/d696cec1323b91c17efd5110f0a71a7ac3eebee8

---

This update fixes SettingToggle implementing icon support among other functionality, along with adequate example code. Updates on SettingToggle for #42 includes:

- impl: edgePadding setter (optional) via env_var, otherwise uses horizontalPadding (default)
- fixes: Icon padding issue (ref  via nillable horizontalPadding (ref. https://github.com/aheze/Setting/pull/38#issuecomment-2614139662, covers https://github.com/aheze/Setting/pull/38, https://github.com/aheze/Setting/pull/37
- impl: SettingToggle extension supporting `.icon(...)` methods
- impl: SettingToggle `onChange(...)` event handler, triggering when toggle is switched on/off
- SettingToggle `toggleIcon` (bool-based https://github.com/AppStorage bindings)
- SettingToggle `.icon(...)` example
- SettingToggle `onChange(...)` example
- SettingToggle switch example is rendered in "Extras" SettingGroup in "Preferences" tab